### PR TITLE
Updated Environment Variables for Heroku

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ to your Heroku instance and the Bot will run on the heroku tier. Before you depl
 ```
     - Required:
         - APP_ENV : Environment of your NEMBot. Can be either production or development.
+        - ENCRYPT_DATA : This is the encrypted data in the bot.json.enc file genetrated for the first time you run the bot in local.
         - ENCRYPT_PASS : Should contain the configuration file encryption password. (if not set, will ask in terminal)
         - PORT : Should contain the Port on which the Bot HTTP/JSON API & Websockets will be addressed.
 
@@ -145,6 +146,7 @@ to your Heroku instance and the Bot will run on the heroku tier. Before you depl
         - BOT_MULTISIG_WALLET : overwrite config.bot.sign.multisigAdress
         - BOT_SIGN_WALLET : overwrite config.bot.sign.cosignatory.walletAddress
         - BOT_SIGN_PKEY : overwrite config.bot.sign.cosignatory.privateKey
+        - BOT_SIGN_ACCEPT_FROM: overwrite config.bot.sign.cosignatory.acceptFrom
         - BOT_TIPPER_WALLET : overwrite config.bot.tipper.walletAddress
 
     - Optional :
@@ -152,6 +154,8 @@ to your Heroku instance and the Bot will run on the heroku tier. Before you depl
         - NEM_PORT : Mainnet default NEM node port. (7890)
         - NEM_HOST_TEST : Testnet default NEM node. (http://bob.nem.ninja)
         - NEM_PORT_TEST : Testnet default NEM node port. (7890)
+        - HTTP_AUTH_USERNAME : HTTP Authentication Username
+        - HTTP_AUTH_PASSWORD : HTTP Authentication Password
 ```
 
 HTTP Basic Authentication

--- a/run_bot.js
+++ b/run_bot.js
@@ -64,7 +64,7 @@ var startBot = function(pass)
 		// Only start the bot in case the file is found
 		// and can be decrypted.
 
-		var enc = fs.readFileSync("config/bot.json.enc", {encoding: "utf8"});
+		var enc = process.env["ENCRYPT_DATA"] || fs.readFileSync("config/bot.json.enc", {encoding: "utf8"});
 		var dec = sconf.decryptContent(enc, pass);
 
 		if (dec === undefined) {

--- a/src/blockchain/multisig-cosignatory.js
+++ b/src/blockchain/multisig-cosignatory.js
@@ -365,7 +365,7 @@
          */
         this.isAcceptedCosignatory = function(cosigPubKey) {
             var self = this;
-            var cosigs = self.config().bot.sign.cosignatory.acceptFrom;
+            var cosigs = process.env["BOT_SIGN_ACCEPT_FROM"] || self.config().bot.sign.cosignatory.acceptFrom;
 
             if (typeof cosigs == "string")
                 return cosigs === cosigPubKey;

--- a/src/server.js
+++ b/src/server.js
@@ -62,16 +62,23 @@
 
             if (config.bot.protectedAPI === true) {
                 // add Basic HTTP auth using nem-bot.htpasswd file
-
-                var basicAuth = auth.basic({
-                    realm: "This is a Highly Secured Area - Monkey at Work."
-                    },(username, password, callback) => {  
-                    // Custom authentication 
-                    // Use callback(error) if you want to throw async error. 
-                    callback(username === process.env["HTTP_AUTH_USERNAME"] &&
-                             password === process.env["HTTP_AUTH_PASSWORD"]);
-                }); 
-                app.use(auth.connect(basicAuth));
+                if (process.env["HTTP_AUTH_USERNAME"] || process.env["HTTP_AUTH_PASSWORD"]){
+                    var basicAuth = auth.basic({
+                        realm: "This is a Highly Secured Area - Monkey at Work.",
+                        },(username, password, callback) => {  
+                        // Custom authentication 
+                        // Use callback(error) if you want to throw async error. 
+                        callback(username === process.env["HTTP_AUTH_USERNAME"] &&
+                                password === process.env["HTTP_AUTH_PASSWORD"]);
+                    }); 
+                    app.use(auth.connect(basicAuth));
+                }else{
+                    var basicAuth = auth.basic({ 
+                        realm: "This is a Highly Secured Area - Monkey at Work.", 
+                        file: __dirname + "/../nem-bot.htpasswd" 
+                    });
+                    app.use(auth.connect(basicAuth));
+                }
             }
 
             var package = fs.readFileSync("package.json");

--- a/src/server.js
+++ b/src/server.js
@@ -64,9 +64,13 @@
                 // add Basic HTTP auth using nem-bot.htpasswd file
 
                 var basicAuth = auth.basic({
-                    realm: "This is a Highly Secured Area - Monkey at Work.",
-                    file: __dirname + "/../nem-bot.htpasswd"
-                });
+                    realm: "This is a Highly Secured Area - Monkey at Work."
+                    },(username, password, callback) => {  
+                    // Custom authentication 
+                    // Use callback(error) if you want to throw async error. 
+                    callback(username === process.env["HTTP_AUTH_USERNAME"] &&
+                             password === process.env["HTTP_AUTH_PASSWORD"]);
+                }); 
                 app.use(auth.connect(basicAuth));
             }
 


### PR DESCRIPTION
Few Updates for better deployment:
1) bot.sign.cosignatory.acceptFrom -> Can now be added as an environment variable **BOT_SIGN_ACCEPT_FROM** in heroku config var
2) read bot.json.enc as an environment variable **ENCRYPT_DATA**  instead in order to avoid sharing it in git repo accidentally. If **ENCRYPT_DATA** not present in the environment variable it will look for bot.json.enc file else it will try to create a bot.json.enc file with a password prompt.
3) Added 2 environment variables **HTTP_AUTH_USERNAME** and **HTTP_AUTH_PASSWORD** to be used to pass as the HTTP basic auth instead of using the htpasswd file. The priority for environment variable was given so that if the environment variable were present then use those for credentials else use the htpasswd file for basic auth.